### PR TITLE
Add macOS and tvOS platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,11 @@ import PackageDescription
 
 let package = Package(
     name: "GridStack",
-    platforms: [.iOS(.v13)],
+    platforms: [
+		.iOS(.v13),
+		.macOS(.v10_15),
+		.tvOS(.v13)
+	],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
It looks like this project works just fine on macOS and tvOS SwiftUI, it just needs to have support added for it in the Package.swift file.

<img width="409" alt="image" src="https://user-images.githubusercontent.com/28552/70412355-7947d500-1a09-11ea-99e5-fae559cee59a.png">

(watchOS has issues running the tests on my machine so I'm not enabling it here, but feel free to add it if it's running for you and it works)