### PR TITLE
Fix issue that the grid doesn't take the whole width

### DIFF
--- a/Sources/GridStack/GridStack.swift
+++ b/Sources/GridStack/GridStack.swift
@@ -37,6 +37,7 @@ public struct GridStack<Content>: View where Content: View {
     public var body: some View {
         GeometryReader { geometry in
             InnerGrid(
+                width: geometry.size.width,
                 spacing: self.spacing,
                 items: self.items,
                 alignment: self.alignment,
@@ -54,6 +55,7 @@ public struct GridStack<Content>: View where Content: View {
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 private struct InnerGrid<Content>: View where Content: View {
     
+    private let width: CGFloat
     private let spacing: CGFloat
     private let rows: [[Int]]
     private let alignment: HorizontalAlignment
@@ -61,12 +63,14 @@ private struct InnerGrid<Content>: View where Content: View {
     private let columnWidth: CGFloat
     
     init(
+        width: CGFloat,
         spacing: CGFloat,
         items: [Int],
         alignment: HorizontalAlignment = .leading,
         @ViewBuilder content: @escaping (Int, CGFloat) -> Content,
         gridDefinition: GridCalculator.GridDefinition
     ) {
+        self.width = width
         self.spacing = spacing
         self.alignment = alignment
         self.content = content
@@ -86,7 +90,9 @@ private struct InnerGrid<Content>: View where Content: View {
                         }
                     }.padding(.horizontal, self.spacing)
                 }
-            }.padding(.top, spacing)
+            }
+            .padding(.top, spacing)
+            .frame(width: width)
         }
     }
 }

--- a/Sources/GridStack/GridStack.swift
+++ b/Sources/GridStack/GridStack.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct GridStack<Content>: View where Content: View {
+    private let edgeInsets: UIEdgeInsets
     private let minCellWidth: CGFloat
     private let spacing: CGFloat
     private let numItems: Int
@@ -17,12 +18,14 @@ public struct GridStack<Content>: View where Content: View {
     private let gridCalculator = GridCalculator()
     
     public init(
+        edgeInsets: UIEdgeInsets = .zero,
         minCellWidth: CGFloat,
         spacing: CGFloat,
         numItems: Int,
         alignment: HorizontalAlignment = .leading,
         @ViewBuilder content: @escaping (Int, CGFloat) -> Content
     ) {
+        self.edgeInsets = edgeInsets
         self.minCellWidth = minCellWidth
         self.spacing = spacing
         self.numItems = numItems
@@ -38,6 +41,7 @@ public struct GridStack<Content>: View where Content: View {
         GeometryReader { geometry in
             InnerGrid(
                 width: geometry.size.width,
+                edgeInsets: self.edgeInsets,
                 spacing: self.spacing,
                 items: self.items,
                 alignment: self.alignment,
@@ -56,6 +60,7 @@ public struct GridStack<Content>: View where Content: View {
 private struct InnerGrid<Content>: View where Content: View {
     
     private let width: CGFloat
+    private let edgeInsets: UIEdgeInsets
     private let spacing: CGFloat
     private let rows: [[Int]]
     private let alignment: HorizontalAlignment
@@ -64,6 +69,7 @@ private struct InnerGrid<Content>: View where Content: View {
     
     init(
         width: CGFloat,
+        edgeInsets: UIEdgeInsets,
         spacing: CGFloat,
         items: [Int],
         alignment: HorizontalAlignment = .leading,
@@ -71,6 +77,7 @@ private struct InnerGrid<Content>: View where Content: View {
         gridDefinition: GridCalculator.GridDefinition
     ) {
         self.width = width
+        self.edgeInsets = edgeInsets
         self.spacing = spacing
         self.alignment = alignment
         self.content = content
@@ -88,11 +95,12 @@ private struct InnerGrid<Content>: View where Content: View {
                             self.content(item, self.columnWidth)
                                 .frame(width: self.columnWidth)
                         }
-                    }.padding(.horizontal, self.spacing)
+                    }
                 }
             }
-            .padding(.top, spacing)
-            .frame(width: width)
+            .padding(.top, edgeInsets.top)
+            .padding(.bottom, edgeInsets.bottom)
+            .frame(width: width - edgeInsets.left - edgeInsets.right)
         }
     }
 }


### PR DESCRIPTION
Firstly thanks for sharing this!

Say I have a grid of 15 items with minWidth 100, and they layout nicely in 3 columns. Now if I filter them into 1 item, then only the center column is shown with that item (which is correct). Upon tapping on the item I push a view, then when the view pops and I clear the filter so items are back to 15, the resulting grid would still retain the 1 column width and won't expand back into the full view.

A google search yields many SO posts about the issue e.g. https://stackoverflow.com/questions/56534772/foreach-inside-scrollview-doesnt-take-whole-width

Setting GeometryReader's width into the VStack solves the problem.

This PR also adds edgeInsets so can specify spacing on each side.