### PR TITLE
Prevent negative layout results in case the available width is zero

### DIFF
--- a/Sources/GridStack/GridCalculator.swift
+++ b/Sources/GridStack/GridCalculator.swift
@@ -11,6 +11,11 @@ struct GridCalculator {
         minimumCellWidth: CGFloat,
         cellSpacing: CGFloat
     ) -> GridDefinition {
+        // Width for views inside a NavigationView might be reported as 0 on the first pass
+        guard availableWidth != 0 else {
+            return (columnWidth: 0, columnCount: 0)
+        }
+        
         /**
          * 1. Subtract the cell spacing once from all the available width
          * 2. Add the cell spacing to each cell Width

--- a/Tests/GridStackTests/GridStackTests.swift
+++ b/Tests/GridStackTests/GridStackTests.swift
@@ -68,11 +68,23 @@ final class GridCalculatorTests: XCTestCase {
         XCTAssertEqual(columnWidth, 280)
     }
     
+    func test_zeroAvailableWidth_givesZeroColumnsAndColumnWidth() {
+        let (columnWidth, columnCount) = subject.calculate(
+            availableWidth: 0,
+            minimumCellWidth: 290,
+            cellSpacing: 10
+        )
+        
+        XCTAssertEqual(columnCount, 0)
+        XCTAssertEqual(columnWidth, 0)
+    }
+    
     static var allTests = [
         ("test_cellsFitExactlyWithoutSpacing", test_threeCellsFitExactlyWithoutSpacing),
         ("test_cellsFitExactlyWithSpacing", test_threeCellsFitExactlyWithSpacing),
         ("test_threeCellsJustDontFit", test_threeCellsJustDontFit),
         ("test_minimumCellWidthIsWiderThanAvailableSpace_givesOneColumn", test_minimumCellWidthIsWiderThanAvailableSpace_givesOneColumn),
-        ("test_minimumCellWidthWithSpacingIsWiderThanAvailableSpace_givesOneColumn", test_minimumCellWidthWithSpacingIsWiderThanAvailableSpace_givesOneColumn)
+        ("test_minimumCellWidthWithSpacingIsWiderThanAvailableSpace_givesOneColumn", test_minimumCellWidthWithSpacingIsWiderThanAvailableSpace_givesOneColumn),
+        ("test_zeroAvailableWidth_givesZeroColumnsAndColumnWidth", test_zeroAvailableWidth_givesZeroColumnsAndColumnWidth)
     ]
 }


### PR DESCRIPTION
Hello there and thanks for this great library. Still got to support iOS 13 so I am glad it exists. 

I've stumbled upon the issue of negative frame sizes being requested myself when using the GridStack inside a NavigationView (see [related Apple Forum Thread](https://developer.apple.com/forums/thread/679248)). This is in line with the issue that has already been reported here: https://github.com/pietropizzi/GridStack/issues/16.

The provided fix is quite simple. Please let me know what you think. Cheers!