### PR TITLE
Prevent stride being called with non-positive Int

### DIFF
--- a/Sources/GridStack/Array+chunked.swift
+++ b/Sources/GridStack/Array+chunked.swift
@@ -1,6 +1,10 @@
 extension Array {
     func chunked(into size: Int) -> [[Element]] {
-        stride(from: 0, to: count, by: size).map {
+        guard size > 0 else {
+            return [self]
+        }
+        
+        return stride(from: 0, to: count, by: size).map {
             Array(self[$0 ..< Swift.min($0 + size, count)])
         }
     }


### PR DESCRIPTION
Hi @pietropizzi, it's me again. Thanks for your quick reaction this morning! 

We might need another release as stride doesn't work that well when the requested size is zero. 

I tested this now against my use case and there are no errors/crashes anymore. 🤞 